### PR TITLE
Practice 3

### DIFF
--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -19,7 +19,20 @@ class Controller_Api_V0_Todo extends Controller_Rest
 
     public function get_list()
     {
-        $todos = Domain_Todo::fetch_todo();
+        $user_id = Session::get('user_id') ?: 0;
+        $todos   = Domain_Todo::fetch_todo($user_id);
+        return $this->response($todos);
+    }
+
+    public function get_list_me()
+    {
+        // on session
+        return $this->get_list();
+    }
+
+    public function get_list_user($id)
+    {
+        $todos   = Domain_Todo::fetch_todo($id);
         return $this->response($todos);
     }
 

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -17,22 +17,20 @@ class Controller_Api_V0_Todo extends Controller_Rest
         return $this->response(Model_Todo::find($id));
     }
 
-    public function get_list()
+    public function get_list($user = 'user', $id = 0)
     {
-        $user_id = Session::get('user_id') ?: 0;
-        $todos   = Domain_Todo::fetch_todo($user_id);
-        return $this->response($todos);
-    }
-
-    public function get_list_me()
-    {
-        // on session
-        return $this->get_list();
-    }
-
-    public function get_list_user($id)
-    {
-        $todos   = Domain_Todo::fetch_todo($id);
+        switch ($user) {
+            case 'user':
+                $user_id = $id;
+                break;
+            case 'me':
+                $user_id = Session::get('user_id');
+                break;
+            default:
+                $user_id = Session::get('user_id') ?: 0;
+                break;
+        }
+        $todos = Domain_Todo::fetch_todo($user_id);
         return $this->response($todos);
     }
 

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -47,11 +47,11 @@ class Controller_Api_V0_Todo extends Controller_Rest
     public function post_item()
     {
         $item = [
-            'name'      => Input::get('name'),
-            'due'       => Input::get('due'),
+            'name'      => Input::post('name'),
+            'due'       => Input::post('due'),
             'status_id' => 0,
             'deleted'   => false,
-            'user_id'   => Session::get('user_id'),
+            'user_id'   => Session::post('user_id'),
         ];
         $id  = Domain_Todo::add_todo($item);
         $uri = $host.'/api/v0/todo/item'.$id;
@@ -65,11 +65,11 @@ class Controller_Api_V0_Todo extends Controller_Rest
     public function put_item($id)
     {
         $item = [
-            'name'      => Input::get('name'),
-            'due'       => Input::get('due'),
-            'status_id' => Input::get('status_id'),
-            'deleted'   => Input::get('deleted'),
-            'user_id'   => Input::get('user_id'),
+            'name'      => Input::put('name'),
+            'due'       => Input::put('due'),
+            'status_id' => Input::put('status_id'),
+            'deleted'   => Input::put('deleted'),
+            'user_id'   => Input::put('user_id'),
         ];
         Domain_Todo::alter($id, $item);
 
@@ -79,11 +79,11 @@ class Controller_Api_V0_Todo extends Controller_Rest
     public function patch_item($id)
     {
         $item = [
-            'name'      => Input::get('name'),
-            'due'       => Input::get('due'),
-            'status_id' => Input::get('status_id'),
-            'deleted'   => Input::get('deleted'),
-            'user_id'   => Input::get('user_id'),
+            'name'      => Input::patch('name'),
+            'due'       => Input::patch('due'),
+            'status_id' => Input::patch('status_id'),
+            'deleted'   => Input::patch('deleted'),
+            'user_id'   => Input::patch('user_id'),
         ];
         $non_null = function ($value) {
             return ! is_null($value);

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -5,6 +5,12 @@
 */
 class Controller_Api_V0_Todo extends Controller_Rest
 {
+    public function before()
+    {
+        parent::before();
+        Domain_Todo::before();
+    }
+
     public function get_todo($id)
     {
         return;

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -1,7 +1,8 @@
 <?php
 
 /**
-* REST API
+* REST API.
+* Create系の操作はTodo ItemのURIを返す
 */
 class Controller_Api_V0_Todo extends Controller_Rest
 {
@@ -92,17 +93,19 @@ class Controller_Api_V0_Todo extends Controller_Rest
 
     public function patch_item($id)
     {
+        $no_change = 'NO_CHANGE';
+        // no key = no change
         $item = [
-            'name'      => Input::patch('name'),
-            'due'       => Input::patch('due'),
-            'status_id' => Input::patch('status_id'),
-            'deleted'   => Input::patch('deleted'),
-            'user_id'   => Input::patch('user_id'),
+            'name'      => Input::patch('name',      $no_change),
+            'due'       => Input::patch('due',       $no_change),
+            'status_id' => Input::patch('status_id', $no_change),
+            'deleted'   => Input::patch('deleted',   $no_change),
+            'user_id'   => Input::patch('user_id',   $no_change),
         ];
-        $non_null = function ($value) {
-            return ! is_null($value);
+        $keep = function ($value) use ($no_change) {
+            return ($value !== $no_change);
         };
-        array_filter($item, $non_null);
+        array_filter($item, $keep);
         $id   = Domain_Todo::alter($id, $item);
         $body = ['item' => Domain_Todo::fetch_item($id)];
 

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -11,32 +11,32 @@ class Controller_Api_V0_Todo extends Controller_Rest
         Domain_Todo::before();
     }
 
-    public function get_todo($id)
+    public function get_item($id)
     {
         return;
     }
 
-    public function get_todo_list()
+    public function get_list()
     {
         return;
     }
 
-    public function delete_todo($id)
+    public function delete_item($id)
     {
         return;
     }
 
-    public function post_todo()
+    public function post_item()
     {
         return;
     }
 
-    public function put_todo($id)
+    public function put_item($id)
     {
         return;
     }
 
-    public function patch_todo($id)
+    public function patch_item($id)
     {
         return;
     }

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -16,8 +16,11 @@ class Controller_Api_V0_Todo extends Controller_Rest
             $error = error_get_last()['type'];
             $fatal = $error === E_ERROR or $error === E_USER_ERROR;
             if ( ! $fatal) { return; }
-            $ob  = ob_get_clean(); // stash Fatal Error Message; discarded
-            $res = $this->response(['errors' => ['FATAL_ERROR']], 500);
+            $ob  = ob_get_clean(); // stash Fatal Error Message
+            $res = $this->response(['errors' => [
+                'FATAL_ERROR',
+                'traces' => array_filter(explode("\n", $ob)),
+            ]], 500);
             $res->send(true);
             exit();
         });

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -12,12 +12,12 @@ class Controller_Api_V0_Todo extends Controller_Rest
         date_default_timezone_set('UTC');
         parent::before();
         Domain_Todo::before();
-        $host = $host ?: 'http://'.Input::server('HTTP_HOST');
+        static::$host = static::$host ?: 'http://'.Input::server('HTTP_HOST');
     }
 
     public function get_item($id)
     {
-        return $this->response(Domain_Todo::fetch_item($id));
+        return $this->response(['item' => Domain_Todo::fetch_item($id)]);
     }
 
     public function get_list($user = 'user', $id = 0)
@@ -35,7 +35,7 @@ class Controller_Api_V0_Todo extends Controller_Rest
         }
         $todos = Domain_Todo::fetch_todo($user_id);
 
-        return $this->response($todos);
+        return $this->response(['list' => $todos]);
     }
 
     public function delete_item($id)
@@ -54,7 +54,7 @@ class Controller_Api_V0_Todo extends Controller_Rest
             'user_id'   => Session::post('user_id'),
         ];
         $id  = Domain_Todo::add_todo($item);
-        $uri = $host.'/api/v0/todo/item'.$id;
+        $uri = static::$host.'/api/v0/todo/item'.$id;
 
         $res = new Response();
         $res->set_status(201);
@@ -91,6 +91,6 @@ class Controller_Api_V0_Todo extends Controller_Rest
         array_filter($item, $non_null);
         $id  = Domain_Todo::alter($id, $item);
 
-        return $this->response(Domain_Todo::fetch_item($id));
+        return $this->response(['item' => Domain_Todo::fetch_item($id)]);
     }
 }

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -25,6 +25,16 @@ class Controller_Api_V0_Todo extends Controller_Rest
         return $res;
     }
 
+    protected static function body_item($id)
+    {
+        return ['item' => Domain_Todo::fetch_item($id)];
+    }
+
+    protected static function body_list($user_id)
+    {
+        return ['list' => Domain_Todo::fetch_todo($id)];
+    }
+
     public function get_item($id)
     {
         try {
@@ -57,8 +67,7 @@ class Controller_Api_V0_Todo extends Controller_Rest
                 $error_list = ['errors' => ['Invalid User']];
                 return $this->response($error_list, 405);
         }
-        $todos = Domain_Todo::fetch_todo($user_id);
-        $body  = ['list' => $todos];
+        $body = static::body_list($user_id);
 
         return $this->response($body);
     }
@@ -84,7 +93,7 @@ class Controller_Api_V0_Todo extends Controller_Rest
             'user_id'   => Session::post('user_id'),
         ];
         $id   = Domain_Todo::add_todo($item);
-        $body = ['item' => Domain_Todo::fetch_item($id)];
+        $body = static::body_item($id);
 
         return $this->response_with_uri($body, 201, $id);
     }
@@ -105,7 +114,7 @@ class Controller_Api_V0_Todo extends Controller_Rest
         };
         array_filter($item, $keep);
         $id   = Domain_Todo::alter($id, $item);
-        $body = ['item' => Domain_Todo::fetch_item($id)];
+        $body = static::body_item($id);
 
         return $this->response_with_uri($body, 200, $id);
     }

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -17,7 +17,7 @@ class Controller_Api_V0_Todo extends Controller_Rest
 
     public function get_item($id)
     {
-        return $this->response(Model_Todo::find($id));
+        return $this->response(Domain_Todo::fetch_item($id));
     }
 
     public function get_list($user = 'user', $id = 0)
@@ -91,6 +91,6 @@ class Controller_Api_V0_Todo extends Controller_Rest
         array_filter($item, $non_null);
         $id  = Domain_Todo::alter($id, $item);
 
-        return $this->response(Model_Todo::find($id));
+        return $this->response(Domain_Todo::fetch_item($id));
     }
 }

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -7,37 +7,64 @@ class Controller_Api_V0_Todo extends Controller_Rest
 {
     public function before()
     {
+        date_default_timezone_set('UTC');
         parent::before();
         Domain_Todo::before();
     }
 
     public function get_item($id)
     {
-        return;
+        return $this->response(Model_Todo::find($id));
     }
 
     public function get_list()
     {
-        return;
+        $todos = Domain_Todo::fetch_todo();
+        return $this->response($todos);
     }
 
     public function delete_item($id)
     {
-        return;
+        Domain_Todo::alter($id, ['deleted' => true]);
     }
 
     public function post_item()
     {
-        return;
+        $item = [
+            'name'      => Input::get('name'),
+            'due'       => Input::get('due'),
+            'status_id' => 0,
+            'deleted'   => false,
+            'user_id'   => Session::get('user_id'),
+        ];
+        Domain_Todo::add_todo($item);
     }
 
     public function put_item($id)
     {
-        return;
+        $item = [
+            'name'      => Input::get('name'),
+            'due'       => Input::get('due'),
+            'status_id' => Input::get('status_id'),
+            'deleted'   => Input::get('deleted'),
+            'user_id'   => Input::get('user_id'),
+        ];
+        Domain_Todo::alter($id, $item);
     }
 
     public function patch_item($id)
     {
-        return;
+        $item = [
+            'name'      => Input::get('name'),
+            'due'       => Input::get('due'),
+            'status_id' => Input::get('status_id'),
+            'deleted'   => Input::get('deleted'),
+            'user_id'   => Input::get('user_id'),
+        ];
+        $non_null = function ($value) {
+            return ! is_null($value);
+        };
+        array_filter($item, $non_null);
+        Domain_Todo::alter($id, $item);
     }
 }

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -11,6 +11,17 @@ class Controller_Api_V0_Todo extends Controller_Rest
 
     public function before()
     {
+        // triggered in LIFO on shutdown
+        Event::register('shutdown', $fatal_error_500 = function () {
+            $error = error_get_last()['type'];
+            $fatal = $error === E_ERROR or $error === E_USER_ERROR;
+            if ( ! $fatal) { return; }
+            $ob  = ob_get_clean(); // stash Fatal Error Message; discarded
+            $res = $this->response(['errors' => ['FATAL_ERROR']], 500);
+            $res->send(true);
+            exit();
+        });
+
         date_default_timezone_set('UTC');
         parent::before();
         Domain_Todo::before();

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -91,23 +91,8 @@ class Controller_Api_V0_Todo extends Controller_Rest
 
     public function put_item($id)
     {
-        $item = [
-            'name'      => Input::put('name'),
-            'due'       => Input::put('due'),
-            'status_id' => Input::put('status_id'),
-            'deleted'   => Input::put('deleted'),
-            'user_id'   => Input::put('user_id'),
-        ];
-        $id   = Domain_Todo::alter($id, $item);
-        $body = ['item' => Domain_Todo::fetch_item($id)];
-
-        return $this->response_with_uri($body, 200, $id);
-    }
-
-    public function patch_item($id)
-    {
-        $no_change = 'NO_CHANGE';
-        // no key = no change
+        $no_change = ' NO_CHANGE ';
+        // no key = no change; input has no trailing space
         $item = [
             'name'      => Input::patch('name',      $no_change),
             'due'       => Input::patch('due',       $no_change),

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+* REST API
+*/
+class Controller_Api_V0_Todo extends Controller_Rest
+{
+    public function get_todo($id)
+    {
+        return;
+    }
+
+    public function get_todo_list()
+    {
+        return;
+    }
+
+    public function delete_todo($id)
+    {
+        return;
+    }
+
+    public function post_todo()
+    {
+        return;
+    }
+
+    public function put_todo($id)
+    {
+        return;
+    }
+
+    public function patch_todo($id)
+    {
+        return;
+    }
+}

--- a/fuelphp/fuel/app/classes/controller/api/v0/todo.php
+++ b/fuelphp/fuel/app/classes/controller/api/v0/todo.php
@@ -46,7 +46,7 @@ class Controller_Api_V0_Todo extends Controller_Rest
 
     protected static function body_list($user_id)
     {
-        return ['list' => Domain_Todo::fetch_todo($id)];
+        return ['list' => Domain_Todo::fetch_todo($user_id)];
     }
 
     public function get_item($id)

--- a/fuelphp/fuel/app/classes/controller/todo.php
+++ b/fuelphp/fuel/app/classes/controller/todo.php
@@ -17,11 +17,12 @@ class Controller_Todo extends Controller
 
     protected function forge_todo_view($data = [])
     {
+        $user_id = Session::get('user_id') ?: 0;
         if ( ! array_key_exists('todos', $data)) {
-            $data['todos'] = Domain_Todo::fetch_todo(Session::get('user_id'));
+            $data['todos'] = Domain_Todo::fetch_todo($user_id);
         }
         $data['status_list'] = Domain_Todo::get('status_list');
-        $data['user_id'] = Session::get('user_id') ?: 0;
+        $data['user_id'] = $user_id;
         return View::forge('todo', $data);
     }
 

--- a/fuelphp/fuel/app/classes/controller/todo.php
+++ b/fuelphp/fuel/app/classes/controller/todo.php
@@ -88,7 +88,7 @@ class Controller_Todo extends Controller
 
     public function action_to_change($id)
     {
-        $todo = Model_Todo::find($id);
+        $todo = Domain_Todo::fetch_item($id);
         list($due_day, $due_time) = Domain_Todo::chop_datetime($todo->due);
         $data['task_to_be_changed'] = [
             'id'        => $todo->id,

--- a/fuelphp/fuel/app/classes/domain/todo.php
+++ b/fuelphp/fuel/app/classes/domain/todo.php
@@ -51,6 +51,11 @@ class Domain_Todo
         return static::fetch_user_todo($user_id)->get();
     }
 
+    public static function fetch_item($id)
+    {
+        return Model_Todo::find($id);
+    }
+
     public static function add_todo($input)
     {
         $due_daytime = Util_String::null_if_blank($input['due_day'].' '.$input['due_time']);
@@ -96,7 +101,7 @@ class Domain_Todo
     public static function alter($id, $updates)
     {
         // suppose no missing id
-        $todo = Model_Todo::find($id);
+        $todo = static::fetch_item($id);
         $todo->set($updates);
         $todo->save();
 

--- a/fuelphp/fuel/app/classes/domain/todo.php
+++ b/fuelphp/fuel/app/classes/domain/todo.php
@@ -62,13 +62,15 @@ class Domain_Todo
         $todo->deleted   = false;
         $todo->user_id   = $input['user_id'];
         $todo->save();
+
+        return $todo->id;
     }
 
     public static function change_todo($id, $input)
     {
         $due_daytime = Util_String::null_if_blank($input['due_day'].' '.$input['due_time']);
 
-        static::alter($id, [
+        return static::alter($id, [
             'name'      => $input['name'],
             'due'       => $due_daytime,
             'status_id' => $input['status_id'],
@@ -97,6 +99,8 @@ class Domain_Todo
         $todo = Model_Todo::find($id);
         $todo->set($updates);
         $todo->save();
+
+        return $todo->id;
     }
 
     /**

--- a/fuelphp/fuel/app/classes/domain/todo.php
+++ b/fuelphp/fuel/app/classes/domain/todo.php
@@ -1,5 +1,8 @@
 <?php
 
+class InvalidIdException extends Exception {}
+class InvalidFormatException extends Exception {}
+
 /**
 * Model dealing with business logics
 */
@@ -53,7 +56,11 @@ class Domain_Todo
 
     public static function fetch_item($id)
     {
-        return Model_Todo::find($id);
+        $item = Model_Todo::find($id);
+        if (is_null($item)) {
+            throw new InvalidIdException();
+        }
+        return $item;
     }
 
     public static function add_todo($input)
@@ -154,7 +161,7 @@ class Domain_Todo
                 $data = Format::forge($table)->to_json();
                 break;
             default:
-                throw new Exception('Invalid format');
+                throw new InvalidFormatException('Invalid format');
         }
         fwrite($temp = tmpfile(), $data);
 

--- a/fuelphp/fuel/app/config/config.php
+++ b/fuelphp/fuel/app/config/config.php
@@ -43,7 +43,7 @@ return array(
 	 */
 	// 'index_file' => false,
 
-	// 'profiling'  => false,
+	'profiling'  => true,
 
 	/**
 	 * Default location for the file cache

--- a/fuelphp/fuel/app/config/rest.php
+++ b/fuelphp/fuel/app/config/rest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Part of the Fuel framework.
+ *
+ * @package    Fuel
+ * @version    1.7
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2015 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+/**
+ * NOTICE:
+ *
+ * If you need to make modifications to the default configuration, copy
+ * this file to your app/config folder, and make them in there.
+ *
+ * This will allow you to upgrade fuel without losing your custom config.
+ */
+
+return array(
+
+	/*
+	| What format should the data be returned in by default?
+	|
+	|	Default: xml
+	|
+	*/
+	'default_format' => 'json',
+
+	/*
+	| XML Basenode name
+	|
+	|	Default: xml
+	|
+	*/
+	'xml_basenode' => 'xml',
+
+	/*
+	| Name for the password protected REST API displayed on login dialogs
+	|
+	|	E.g: My Secret REST API
+	|
+	*/
+	'realm' => 'REST API',
+
+	/*
+	| Is login required and if so, which type of login?
+	|
+	|	'' = no login required,
+	| 'basic' = unsecure login,
+	| 'digest' = more secure login
+	| or define a method name in your REST controller that handles authorization
+	|
+	*/
+	'auth' => '',
+
+	/*
+	| array of usernames and passwords for login
+	|
+	|	array('admin' => '1234')
+	|
+	*/
+	'valid_logins' => array('admin' => '1234'),
+
+	/*
+	| Ignore HTTP_ACCEPT
+	|
+	| A lot of work can go into detecting incoming data,
+	| disabling this will speed up your requests if you do not use a ACCEPT header.
+	|
+	*/
+	'ignore_http_accept' => true,
+
+);


### PR DESCRIPTION
# REST API

Controllerのみ実装
## 仕様
- 共通: `/api/v0/todo`
- Default Format: json
  - 拡張子でも指定可能
  - HEADERは無視
    - (撤廃?)
  - TODO: `.php`で生のORMオブジェクトが見えるのを阻止
- `/item/:id`
  - IDで指定
  - `item` node以下に格納
- `/list`
  - `GET`のみ
  - `list` node以下に格納
  - default: `Session`からユーザーごとのIDで切り替え
    - `user 0` のテストユーザーにfallback
  - `/me`: 現`Session`からuser ID取得
  - `/user/:id`: Authは無し
- Create系はURIをLocation headerに付与
### Test

なし
